### PR TITLE
patch deprecated fixer.io API to FOSS alternative

### DIFF
--- a/src/http/CurrencyConversion.js
+++ b/src/http/CurrencyConversion.js
@@ -7,7 +7,7 @@ export default {
                 resolve(1);
             });
         }
-        return axios.get(`https://api.fixer.io/latest?base=${from}&symbols=${to}`).then((result => {
+        return axios.get(`https://api.exchangeratesapi.io/latest?base=${from}&symbols=${to}`).then((result => {
             return (result.data.rates[to]);
         }));
     }


### PR DESCRIPTION
[ExchangeRatesAPI](http://exchangeratesapi.io/) is a FOSS alternative to Fixer, which has deprecated their old API and subsequently broken the currency conversion element of this project.